### PR TITLE
Use ActiveRecord::Batches#in_batches to pluck batches

### DIFF
--- a/lib/pluck_each.rb
+++ b/lib/pluck_each.rb
@@ -14,32 +14,13 @@ module ActiveRecord
       end
     end
 
-    def pluck_in_batches(*args)
-      options = args.extract_options!
-      relation = self
+    def pluck_in_batches(*column_names)
+      options = column_names.extract_options!
       batch_size = options[:batch_size] || 1000
-      offset = 0
 
-      relation = relation.reorder(pluck_batch_order).offset(offset).limit(batch_size)
-      records = relation.pluck(*args)
-
-      while records.any?
-        records_size = records.size
-        offset += records_size
-        break if records_size <= 0
-
-        yield records
-
-        break if records_size < batch_size
-        records = relation.offset(offset).limit(batch_size).pluck(*args)
+      in_batches(:of => batch_size, :load => false) do |batch|
+        yield batch.pluck(*column_names)
       end
     end
-
-    private
-
-    def pluck_batch_order
-      "#{quoted_table_name}.#{quoted_primary_key} ASC"
-    end
-
   end
 end


### PR DESCRIPTION
Using SQL offsets when paging over records causes problems when the yielded block modifies the data being paged over (i.e. deleting records in batches).

To mitigate this, ActiveRecord::Batches uses the last ID of each batch to create a lower limit instead of a SQL offset. This pattern ensures that the entire data set is paged over.

Update `pluck_in_batches` to simply use the ActiveRecord::Batches#`in_batches` method to page over records just like `find_in_batches` does.

This is an alternative to #2. The advantage is that it relies on any changes to the `ActiveRecord::Batches` module and will always have parity with `find_in_batches`. The disadvantage is that it does 2N queries where N is the number or batches.