### PR TITLE
Fix for usage with Rails 6.1

### DIFF
--- a/lib/pluck_each.rb
+++ b/lib/pluck_each.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       relation = self
       batch_size = options[:batch_size] || 1000
 
-      relation = relation.reorder(batch_order).limit(batch_size)
+      relation = relation.reorder(:asc).limit(batch_size)
       batch_relation = relation
 
       loop do

--- a/lib/pluck_each.rb
+++ b/lib/pluck_each.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       relation = self
       batch_size = options[:batch_size] || 1000
 
-      relation = relation.reorder(:asc).limit(batch_size)
+      relation = relation.reorder(batch_order(:asc)).limit(batch_size)
       batch_relation = relation
 
       loop do

--- a/pluck_each.gemspec
+++ b/pluck_each.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", "> 3.2.0"
   spec.add_dependency "activesupport", "> 3.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "pry"

--- a/pluck_each.gemspec
+++ b/pluck_each.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "> 3.2.0"
-  spec.add_dependency "activesupport", "> 3.0.0"
+  spec.add_dependency "activerecord", ">= 6.1.0"
+  spec.add_dependency "activesupport", ">= 6.1.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
This fixes the usage of Rails' internal `#batch_order` method (see [the changes in rails](https://github.com/rails/rails/commit/4d0c335cbb7d16bbd5d24106365caff14c4f53ff#diff-8facabeda611c44c59470e0f632a5805f152e40ec63ed7a75c76896e783ddb5d)).