### PR TITLE
Update pluck_each to reference new method build_batch_orders

### DIFF
--- a/lib/pluck_each.rb
+++ b/lib/pluck_each.rb
@@ -8,7 +8,9 @@ end
 module ActiveRecord
   module Batches
 
-    IS_RAILS_6_1_PLUS = ::Gem::Version.new(::ActiveRecord.version) >= ::Gem::Version.new("6.1.0")
+    IS_RAILS_6_1_PLUS = ::Gem::Version.new(::ActiveRecord.version) >= ::Gem::Version.new("6.1.0") && ::Gem::Version.new(::ActiveRecord.version) < ::Gem::Version.new("7.1.0")
+
+    IS_RAILS_7_1_PLUS = ::Gem::Version.new(::ActiveRecord.version) >= ::Gem::Version.new("7.1.0")
 
     def pluck_each(*args)
       pluck_in_batches(*args) do |values|
@@ -29,7 +31,9 @@ module ActiveRecord
       relation = self
       batch_size = options[:batch_size] || 1000
 
-      if IS_RAILS_6_1_PLUS
+      if IS_RAILS_7_1_PLUS
+        relation = relation.reorder(build_batch_orders(:asc).to_h)
+      elsif IS_RAILS_6_1_PLUS
         relation = relation.reorder(batch_order(:asc)).limit(batch_size)
       else
         relation = relation.reorder(batch_order).limit(batch_size)


### PR DESCRIPTION
Update pluck_each to reference new method build_batch_orders that replaced batch_order in rails 7.1

`batch_order` was removed
https://github.com/rails/rails/commit/9452b59506663255d2ce04f1cc46ea7e22bacf67#diff-8facabeda611c44c59470e0f632a5805f152e40ec63ed7a75c76896e783ddb5dL315

and instead `build_batch_orders` was introduced and utilized in the following way:


[relation.reorder(batch_orders.to_h).limit(batch_limit)](https://github.com/rails/rails/commit/9452b59506663255d2ce04f1cc46ea7e22bacf67#diff-8facabeda611c44c59470e0f632a5805f152e40ec63ed7a75c76896e783ddb5dR261)